### PR TITLE
Fix package failure as test failure

### DIFF
--- a/testdata/35-report.xml
+++ b/testdata/35-report.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="1" failures="1" time="21.630" name="vitess.io/vitess/go/test/endtoend/vtgate/queries/aggregation">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="aggregation" name="Failure" time="0.000">
+			<failure message="Failed" type="">running tests for  vitess.io/vitess/go/test/endtoend/vtgate/queries/aggregation&#xA;E1101 10:02:58.832465   21079 tablet.go:242] unable to connect to tablet cell:&#34;test_union&#34; uid:5559: node doesn&#39;t exist: /test_union/tablets/test_union-0000005559/Tablet&#xA;F1101 10:02:58.842306   21079 run.go:50] listen tcp :16022: bind: address already in use&#xA;E1101 10:02:59.023686   17409 cluster_process.go:334] error starting vttablet for tablet uid 5559, grpc port 16023: process &#39;vttablet&#39; timed out after 10s (err: process &#39;vttablet&#39; exited prematurely (err: exit status 1))</failure>
+		</testcase>
+	</testsuite>
+	<testsuite tests="3" failures="0" time="32.140" name="vitess.io/vitess/go/test/endtoend/vtgate/queries/aggregation">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="aggregation" name="TestAggregateTypes" time="0.130"></testcase>
+		<testcase classname="aggregation" name="TestGroupBy" time="0.050"></testcase>
+		<testcase classname="aggregation" name="TestDistinct" time="0.070"></testcase>
+	</testsuite>
+</testsuites>

--- a/testdata/35-retry_package_pass.txt
+++ b/testdata/35-retry_package_pass.txt
@@ -1,0 +1,15 @@
+running tests for  vitess.io/vitess/go/test/endtoend/vtgate/queries/aggregation
+E1101 10:02:58.832465   21079 tablet.go:242] unable to connect to tablet cell:"test_union" uid:5559: node doesn't exist: /test_union/tablets/test_union-0000005559/Tablet
+F1101 10:02:58.842306   21079 run.go:50] listen tcp :16022: bind: address already in use
+E1101 10:02:59.023686   17409 cluster_process.go:334] error starting vttablet for tablet uid 5559, grpc port 16023: process 'vttablet' timed out after 10s (err: process 'vttablet' exited prematurely (err: exit status 1))
+FAIL	vitess.io/vitess/go/test/endtoend/vtgate/queries/aggregation	21.630s
+FAIL
+running tests for  vitess.io/vitess/go/test/endtoend/vtgate/queries/aggregation
+=== RUN   TestAggregateTypes
+--- PASS: TestAggregateTypes (0.13s)
+=== RUN   TestGroupBy
+--- PASS: TestGroupBy (0.05s)
+=== RUN   TestDistinct
+--- PASS: TestDistinct (0.07s)
+PASS
+ok  	vitess.io/vitess/go/test/endtoend/vtgate/queries/aggregation	32.140s

--- a/testdata/36-report.xml
+++ b/testdata/36-report.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="1" failures="1" time="0.141" name="package/name1">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="name1" name="Failure" time="0.000">
+			<failure message="Failed" type="">running tests for  package/name1</failure>
+		</testcase>
+	</testsuite>
+	<testsuite tests="2" failures="1" time="0.151" name="package/name1">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="name1" name="TestOne" time="0.020">
+			<failure message="Failed" type="">file_test.go:11: Error message&#xA;file_test.go:11: Longer&#xA;&#x9;error&#xA;&#x9;message.</failure>
+		</testcase>
+		<testcase classname="name1" name="TestTwo" time="0.130"></testcase>
+	</testsuite>
+	<testsuite tests="1" failures="1" time="0.183" name="package/name1">
+		<properties>
+			<property name="go.version" value="1.0"></property>
+		</properties>
+		<testcase classname="name1" name="Failure" time="0.000">
+			<failure message="Failed" type="">running tests for  package/name1</failure>
+		</testcase>
+	</testsuite>
+</testsuites>

--- a/testdata/36-retry_package_fail.txt
+++ b/testdata/36-retry_package_fail.txt
@@ -1,0 +1,17 @@
+running tests for  package/name1
+FAIL	package/name1	0.141s
+FAIL
+running tests for  package/name1
+=== RUN TestOne
+--- FAIL: TestOne (0.02 seconds)
+	file_test.go:11: Error message
+	file_test.go:11: Longer
+		error
+		message.
+=== RUN TestTwo
+--- PASS: TestTwo (0.13 seconds)
+FAIL
+FAIL	package/name1 0.151s
+running tests for  package/name1
+FAIL	package/name1	0.183s
+FAIL


### PR DESCRIPTION
If the package test does not start due to failure in setup and on re-run the test starts (fail/pass), we should ignore the run of failed package start to make the CI run as a failure.