### PR TITLE
Do not report `No test result found` errors

### DIFF
--- a/junit/junit.go
+++ b/junit/junit.go
@@ -217,10 +217,12 @@ func createTestcaseForTest(pkgName string, test gtr.Test) Testcase {
 			Data:    formatOutput(test.Output, test.Level),
 		}
 	} else if test.Result == gtr.Unknown {
-		tc.Error = &Result{
-			Message: "No test result found",
-			Data:    formatOutput(test.Output, test.Level),
-		}
+		// We do not want to report "No test result found" errors in the XML file
+		// as they will anyway appear as errors and fail the overall test.
+		// tc.Error = &Result{
+		// 	Message: "No test result found",
+		// 	Data:    formatOutput(test.Output, test.Level),
+		// }
 	} else if len(test.Output) > 0 {
 		tc.SystemOut = &Output{Data: formatOutput(test.Output, test.Level)}
 	}

--- a/junit/junit_test.go
+++ b/junit/junit_test.go
@@ -48,14 +48,14 @@ func TestCreateFromReport(t *testing.T) {
 
 	want := Testsuites{
 		Tests:    6,
-		Errors:   3,
+		Errors:   2,
 		Failures: 1,
 		Skipped:  1,
 		Suites: []Testsuite{
 			{
 				Name:      "package/name",
 				Tests:     6,
-				Errors:    3,
+				Errors:    2,
 				ID:        0,
 				Failures:  1,
 				Skipped:   1,
@@ -88,7 +88,6 @@ func TestCreateFromReport(t *testing.T) {
 						Name:      "TestIncomplete",
 						Classname: "package/name",
 						Time:      "0.000",
-						Error:     &Result{Message: "No test result found"},
 					},
 					{
 						Classname: "Build error",


### PR DESCRIPTION
This Pull Request removes the code that reports `No test result found` errors in the XML file. We want to remove these errors since they automatically fail the Launchable build even though the errors are not counted in the report's final results, simply having them in the XML's logs will fail the build.

When copying the `go test` output of the `vtadmin` package to a text file named `t`, the following would happen before this Pull Request:

```
$ cat t | go-junit-report -set-exit-code | grep "No test result found"
                        <error message="No test result found"></error>
                        <error message="No test result found"></error>
                        <error message="No test result found"></error>
                        <error message="No test result found"></error>
                        <error message="No test result found"></error>
                        <error message="No test result found"></error>
                        <error message="No test result found"></error>
                        <error message="No test result found"></error>
                        <error message="No test result found"></error>
                        <error message="No test result found"></error>
                        <error message="No test result found"></error>
                        <error message="No test result found"></error>
                        <error message="No test result found"></error>
                        <error message="No test result found"></error>
                        <error message="No test result found"></error>
                        <error message="No test result found"></error>
$
```

Now after the patch, the following happens:

```
$ go install github.com/vitessio/go-junit-report@fix-report
$ cat t | go-junit-report -set-exit-code | grep "No test result found"
$
```